### PR TITLE
[Forwardport] Default Welcome message is broken on storefront with enabled translate-inline

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
@@ -13,7 +13,7 @@ if ($block->isLoggedIn()) {
     $dataPostParam = sprintf(" data-post='%s'", $block->getPostParams());
 }
 ?>
-<li class="authorization-link" data-label="<?= $block->escapeHtmlAttr(__('or')) ?>">
+<li class="authorization-link" data-label="<?= $block->escapeHtml(__('or')) ?>">
     <a <?= /* @noEscape */ $block->getLinkAttributes() ?><?= /* @noEscape */ $dataPostParam ?>>
         <?= $block->escapeHtml($block->getLabel()) ?>
     </a>

--- a/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
@@ -13,7 +13,7 @@ if ($block->isLoggedIn()) {
     $dataPostParam = sprintf(" data-post='%s'", $block->getPostParams());
 }
 ?>
-<li class="authorization-link" data-label="<?= $block->escapeHtml(__('or')) ?>">
+<li class="authorization-link" data-label="<?= $block->escapeHtmlAttr(__('or')) ?>">
     <a <?= /* @noEscape */ $block->getLinkAttributes() ?><?= /* @noEscape */ $dataPostParam ?>>
         <?= $block->escapeHtml($block->getLabel()) ?>
     </a>

--- a/app/code/Magento/Theme/view/frontend/templates/html/header.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/header.phtml
@@ -19,7 +19,7 @@ $welcomeMessage = $block->getWelcome();
             </span>
             <!-- /ko -->
             <!-- ko ifnot: customer().fullname  -->
-            <span data-bind='html:"<?= $block->escapeHtmlAttr($welcomeMessage) ?>"'></span>
+            <span data-bind='html:"<?= $block->escapeHtml($welcomeMessage) ?>"'></span>
             <?= $block->getBlockHtml('header.additional') ?>
             <!-- /ko -->
         </li>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13038
Description
Earlier escapeHtmlAttr() is used instead of escapeHtml(). As it is simple message so we have replaced this method: escapeHtmlAttr() with escapeHtml().

1. magento/magento2#12711: Default Welcome message is broken on storefront with enabled translate-inline