### PR TITLE
[Forwardport] Added missing event parameter for proxy function on the search form submit

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -104,8 +104,8 @@ define([
             this.element.on('keydown', this._onKeyDown);
             this.element.on('input propertychange', this._onPropertyChange);
 
-            this.searchForm.on('submit', $.proxy(function () {
-                this._onSubmit();
+            this.searchForm.on('submit', $.proxy(function (e) {
+                this._onSubmit(e);
                 this._updateAriaHasPopup(false);
             }, this));
         },


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13811
### Description
When submitting the search form (mini) with an empty value, an error is throw on preventDefault

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13791

### Manual testing scenarios
1. See description and testing scenario in original issue https://github.com/magento/magento2/issues/13791

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
