### PR TITLE
[Forwardport] Inconsistent Redirect in Admin Notification Controller

### DIFF
--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassRemove.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassRemove.php
@@ -40,6 +40,5 @@ class MassRemove extends \Magento\AdminNotification\Controller\Adminhtml\Notific
             }
         }
         $this->_redirect('adminhtml/*/');
-        return;
     }
 }

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassRemove.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassRemove.php
@@ -39,6 +39,7 @@ class MassRemove extends \Magento\AdminNotification\Controller\Adminhtml\Notific
                 $this->messageManager->addException($e, __("We couldn't remove the messages because of an error."));
             }
         }
-        $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl($this->getUrl('*')));
+        $this->_redirect('adminhtml/*/');
+        return;
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13828
This controller has an inconsistent redirect mechanism (than other controllers in admin-notification).  This means that if the admin has a different URL, the admin user is returned to the frontend URL of the default store instead.

### Manual testing scenarios
1) Setup admin to run on a separate domain to the main site
2) Attempt to mass remove all notifications within admin